### PR TITLE
Change popup window "Falsche Version des Untersuchungsauftrags verwendet" v2

### DIFF
--- a/src/app/core/model/data-service-error.ts
+++ b/src/app/core/model/data-service-error.ts
@@ -20,7 +20,7 @@ export class InputChangedError extends ClientError {
 }
 
 export class ExcelVersionError extends ClientError {
-    constructor(public version: string,...args: any[]) {
+    constructor(public version: string, public currentVersions: string[], ...args: any[]) {
         // eslint-disable-next-line
         super(...args);
         Object.setPrototypeOf(this, ExcelVersionError.prototype);

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -186,9 +186,10 @@ export class DataService {
                 if (error instanceof EndpointError) {
                     if (error.errorDTO.version) {
                         const excelVersion: string = error.errorDTO.version;
+                        const currentVersions: string[] = error.errorDTO.currentVersions || [];
                         switch (error.errorDTO.code) {
                             case 7:
-                                throw new ExcelVersionError(excelVersion, 'Invalid excel version error.');
+                                throw new ExcelVersionError(excelVersion, currentVersions, 'Invalid excel version error.');
                             default:
                                 throw error;
                         }

--- a/src/app/samples/import-samples/components/excel-version-dialog.component.html
+++ b/src/app/samples/import-samples/components/excel-version-dialog.component.html
@@ -4,25 +4,36 @@
         <br />
         <div mat-dialog-content>
             <br />
-            <p class="mibi-dialog-text-style-yellow">
-                <span class="mibi-dialog-text-style">{{ data.string0 }}</span>
-            </p>
-            <p>
-                <span class="mibi-dialog-text-style">{{ data.string1 }}</span>
-            </p>
-            <p>
-                <span class="mibi-dialog-text-style">{{ data.string2 }}</span>
-            </p>
-            <p>
-                <span class="mibi-dialog-text-style">{{ data.string3 }} </span>
-                <span class="mibi-dialog-text-style mibi-dialog-text-style-underline">{{ data.string4 }} </span>
-            </p>
-            <br />
-            <p class="mibi-link mibi-dialog-text-style"><a target="_blank" href="{{ data.link }}">{{ data.link }}</a></p>
-            <br />
-            <p>
-                <span class="mibi-dialog-text-style">{{ data.string5 }}</span>
-            </p>
+            <ng-container *ngIf="!data.useAlternativeTexts">
+                <p class="mibi-dialog-text-style-yellow">
+                    <span class="mibi-dialog-text-style">{{ data.string0 }}</span>
+                </p>
+                <p>
+                    <span class="mibi-dialog-text-style">{{ data.string1 }}</span>
+                </p>
+                <p>
+                    <span class="mibi-dialog-text-style">{{ data.string2 }}</span>
+                </p>
+                <p>
+                    <span class="mibi-dialog-text-style">{{ data.string3 }} </span>
+                    <span class="mibi-dialog-text-style mibi-dialog-text-style-underline">{{ data.string4 }} </span>
+                </p>
+                <br />
+                <p class="mibi-link mibi-dialog-text-style"><a target="_blank" href="{{ data.link }}">{{ data.link }}</a></p>
+                <br />
+                <p>
+                    <span class="mibi-dialog-text-style">{{ data.string5 }}</span>
+                </p>
+            </ng-container>
+            <ng-container *ngIf="data.useAlternativeTexts">
+                <p>
+                    <span class="mibi-dialog-text-style">{{ data.alternativeText2a }}</span>
+                </p>
+                <br />
+                <p>
+                    <span class="mibi-dialog-text-style">{{ data.alternativeText3a }}</span>
+                </p>
+            </ng-container>
         </div>
 
         <div mat-dialog-actions class="mibi-mat-dialog-cancel-actions">

--- a/src/app/samples/import-samples/components/excel-version-dialog.component.ts
+++ b/src/app/samples/import-samples/components/excel-version-dialog.component.ts
@@ -7,15 +7,20 @@ import { dialogCancelMTA } from '../../../shared/dialog/state/dialog.actions';
 
 export interface ExcelVersionDialogData {
     title: string;
-    string0: string;
-    string1: string;
-    string2: string;
-    string3: string;
-    string4: string;
-    link: string;
-    string5: string;
     cancelButtonText: string;
-  }
+    useAlternativeTexts: boolean;
+    // V16 and below:
+    string0?: string;
+    string1?: string;
+    string2?: string;
+    string3?: string;
+    string4?: string;
+    link?: string;
+    string5?: string;
+    // V17 and above:
+    alternativeText2a?: string;
+    alternativeText3a?: string;
+}
 
 @Component({
     selector: 'mibi-send-excel-version-dialog',

--- a/src/app/samples/import-samples/import-samples.constants.ts
+++ b/src/app/samples/import-samples/import-samples.constants.ts
@@ -3,7 +3,7 @@ export const importSamplesWrongVersionDialogStrings = {
     message0: `Der Untersuchungsauftrag (ehemals "Einsendebogen") V16 wird ab dem 01.01.2027 nicht mehr akzeptiert.
     Somit können dann - drei Jahre nach Einführung des AVV DatA-Formats - keine ADV-Codes mehr an das BfR gemeldet werden.
     Bitte verwenden Sie nur noch den Untersuchungsauftrag V18 und AVV DatA-Codes.`,
-    message1: `Sie haben versucht, einen Untersuchungsauftrag der Version `,
+    message1: `Sie haben versucht, einen Untersuchungsauftrag der Version`,
     message2: `hochzuladen.`,
     message3: `Version 16 und frühere Versionen des Untersuchungsauftrags sind für ADV-codierte Daten gedacht.`,
     message4: `Wenn Sie ADV-codierte Daten an das BfR melden möchten, `,
@@ -11,8 +11,16 @@ export const importSamplesWrongVersionDialogStrings = {
 
     link: 'https://nolar-dev.bfr.berlin/users/login',
 
-    message6: `Dieses MiBi-Portal ist ausschließlich für AVV DatA-codierte Daten vorgesehen,
-    die Sie über den Untersuchungsauftrag ab Version 17 hier hochladen können.`,
+    message6Part1: `Dieses MiBi-Portal ist ausschließlich für AVV DatA-codierte Daten vorgesehen,
+    die Sie über den Untersuchungsauftrag ab Version`,
+    message6Part2: `hier hochladen können.`,
+
+    alternativeMessage2aPart1: `Sie haben versucht, einen Untersuchungsauftrag der Version`,
+    alternativeMessage2aPart2: `hochzuladen. Diese Version wird nicht länger unterstützt.`,
+
+    alternativeMessage3aPart1: `Zur Meldung von AVV DatA-codierten Isolatdaten verwenden Sie bitte die aktuelle Version`,
+    alternativeMessage3aPart2: `des Untersuchungsauftrags. Sie können diese Version über den Button „Excel-Vorlage“ oben rechts im hellblauen Menüband herunterladen.`,
+
     cancelButtonText: 'Zurück zum AVV-MiBi-Portal'
 };
 

--- a/src/app/samples/import-samples/import-samples.effects.ts
+++ b/src/app/samples/import-samples/import-samples.effects.ts
@@ -88,22 +88,48 @@ export class ImportSamplesEffects {
 
     private openExcelVersionDialog(error: ExcelVersionError) {
         const strings = importSamplesWrongVersionDialogStrings;
-        const version = error.version;
-        const dialogData: ExcelVersionDialogData = {
-            title: strings.title,
-            string0: strings.message0,
-            string1: `${strings.message1} ${version} ${strings.message2}`,
-            string2: strings.message3,
-            string3: strings.message4,
-            string4: strings.message5,
-            link: strings.link,
-            string5: strings.message6,
-            cancelButtonText: strings.cancelButtonText
-        };
+        const uploadedVersion = error.version;
+        const currentVersions = error.currentVersions;
+        const versionNumber = Number.parseInt(uploadedVersion, 10);
+        const useAlternativeTexts = versionNumber >= 17;
+
+        let dialogData: ExcelVersionDialogData;
+        let dialogHeight: string;
+
+        if (useAlternativeTexts) {
+            const currentVersion = currentVersions.length > 0
+                ? String(Math.max(...currentVersions.map(v => Number.parseInt(v, 10))))
+                : '';
+            dialogData = {
+                title: strings.title,
+                cancelButtonText: strings.cancelButtonText,
+                useAlternativeTexts: true,
+                alternativeText2a: `${strings.alternativeMessage2aPart1} ${uploadedVersion} ${strings.alternativeMessage2aPart2}`,
+                alternativeText3a: `${strings.alternativeMessage3aPart1} ${currentVersion} ${strings.alternativeMessage3aPart2}`
+            };
+            dialogHeight = '32em';
+        } else {
+            const currentVersion = currentVersions.length > 0
+                ? String(Math.min(...currentVersions.map(v => Number.parseInt(v, 10))))
+                : '';
+            dialogData = {
+                title: strings.title,
+                cancelButtonText: strings.cancelButtonText,
+                useAlternativeTexts: false,
+                string0: strings.message0,
+                string1: `${strings.message1} ${uploadedVersion} ${strings.message2}`,
+                string2: strings.message3,
+                string3: strings.message4,
+                string4: strings.message5,
+                link: strings.link,
+                string5: `${strings.message6Part1} ${currentVersion} ${strings.message6Part2}`
+            };
+            dialogHeight = '52em';
+        }
 
         const dialogConfig = {
             data: dialogData,
-            height: '52em',
+            height: dialogHeight,
             width: '65em'
         };
 


### PR DESCRIPTION
fix: wrong excel version popup

Ticket:https://github.com/SiLeBAT/mibi-portal-client/issues/696

....................................................................................................
  **client**

1. data-service-error.ts
  Added currentVersions: string[] to ExcelVersionError so the client can store the versions received from the server.

  2. data.service.ts
  Extracts currentVersions from the error DTO response and passes it into ExcelVersionError.

  3. import-samples.constants.ts
  - Split message6 into message6Part1 and message6Part2 so the dynamic version number can be inserted in the middle
  - Added alternativeMessage2aPart1/2 and alternativeMessage3aPart1/2 for the V17+ case

  4. import-samples.effects.ts
  This is the main logic. openExcelVersionDialog now:
  - Checks if uploadedVersion >= 17 → use alternative texts (2a, 3a), picks the max current version
  - Checks if uploadedVersion <= 16 → use existing texts, picks the min current version for message6

  5. excel-version-dialog.component.html + .ts
  - Interface updated with useAlternativeTexts: boolean flag and optional fields for both cases
  - Template uses *ngIf="!data.useAlternativeTexts" / *ngIf="data.useAlternativeTexts" to conditionally show either the full existing layout (V16) or 
  the simplified two-text layout (V17+)

.....................................................................
                                                                                                          
                                                                                                                    

