### PR TITLE
AVV DatA sample is not checked directly when uploading a sheet and then logging in

### DIFF
--- a/src/app/user/container/login-container/login-container.component.ts
+++ b/src/app/user/container/login-container/login-container.component.ts
@@ -10,6 +10,7 @@ import { UserMainSlice } from '../../user.state';
 import { userLoginSSA } from '../../state/user.actions';
 import { navigateMSA } from '../../../shared/navigate/navigate.actions';
 import { SamplesLinkProviderService } from '../../../samples/link-provider.service';
+import { validateSamplesSSA } from '../../../samples/validate-samples/validate-samples.actions';
 
 @Component({
     selector: 'mibi-login-container',
@@ -35,6 +36,7 @@ export class LoginContainerComponent implements OnInit, OnDestroy {
             tap(([currentUser, hasEntries]) => {
                 if (currentUser) {
                     if (hasEntries) {
+                        this.store$.dispatch(validateSamplesSSA());
                         this.store$.dispatch(navigateMSA({ path: this.samplesLinks.editor }));
                     } else {
                         this.store$.dispatch(navigateMSA({ path: this.samplesLinks.upload }));


### PR DESCRIPTION
AVV DatA sample is not checked directly when uploading a sheet and then logging in
Ticket:https://github.com/SiLeBAT/mibi-portal-client/issues/690

...................................................................................................
 Now when the login redirect happens and the user has existing sample data, validateSamplesSSA is dispatched first. This triggers a fresh call to /v2/samples/validated — this time with authentication — so the server checks the AVV numbers and returns the warnings, which the grid then displays immediately.