### PR TITLE
Wire Angular client to Keycloak BFF auth (02b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ ts-jest.log
 .settings/
 *.sublime-workspace
 
+# AI
+.claude/
+AGENTS.md
+CLAUDE.md
+
 # IDE - VSCode
 .vscode/*
 !.vscode/settings.json
@@ -40,6 +45,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+/local
 
 # e2e
 /cypress/videos
@@ -52,3 +58,4 @@ testem.log
 Thumbs.db
 
 local/
+.gitnexus

--- a/angular.json
+++ b/angular.json
@@ -138,7 +138,5 @@
       "@angular-eslint/schematics"
     ],
     "analytics": false
-    
-    
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,23 +1,24 @@
+import { HTTP_INTERCEPTORS, HttpClientXsrfModule } from '@angular/common/http';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import { StoreModule } from '@ngrx/store';
-import { StoreDevtoolsModule } from '@ngrx/store-devtools';
-import { AppComponent } from './app.component';
-import { TokenInterceptor } from './core/services/token-interceptor.service';
-import { HttpErrorMapperService } from './core/services/http-error-mapper.service';
-import { AppRoutingModule } from './app-routing.module';
-import { CoreModule } from './core/core.module';
-import { SharedModule } from './shared/shared.module';
-import { SamplesModule } from './samples/samples.module';
-import { UserModule } from './user/user.module';
-import { environment } from '../environments/environment';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreRouterConnectingModule, routerReducer } from '@ngrx/router-store';
+import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { environment } from '../environments/environment';
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
 import { ContentModule } from './content/content.module';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CoreModule } from './core/core.module';
+import { HttpErrorMapperService } from './core/services/http-error-mapper.service';
+import { TokenInterceptor } from './core/services/token-interceptor.service';
 import { MainModule } from './main/main.module';
 import { OrdersModule } from './orders/orders.module';
+import { SamplesModule } from './samples/samples.module';
+import { SharedModule } from './shared/shared.module';
+import { AppAuthService } from './user/services/app-auth.service';
+import { UserModule } from './user/user.module';
 
 @NgModule({
     declarations: [
@@ -52,11 +53,15 @@ import { OrdersModule } from './orders/orders.module';
         UserModule,
         ContentModule,
         OrdersModule,
+        HttpClientXsrfModule.withOptions({ cookieName: 'XSRF-TOKEN', headerName: 'X-XSRF-TOKEN' }),
         StoreRouterConnectingModule.forRoot(),
         // AppRoutingModule needs to be at the end
         AppRoutingModule
     ],
     providers: [
+        // TokenInterceptor only attaches a Bearer header when a legacy token is
+        // present in storage, so it is a no-op in Keycloak (cookie-session) mode
+        // and can be registered unconditionally.
         {
             provide: HTTP_INTERCEPTORS,
             useClass: TokenInterceptor,
@@ -65,6 +70,12 @@ import { OrdersModule } from './orders/orders.module';
         {
             provide: HTTP_INTERCEPTORS,
             useClass: HttpErrorMapperService,
+            multi: true
+        },
+        {
+            provide: APP_INITIALIZER,
+            useFactory: (auth: AppAuthService) => async () => auth.bootstrap(),
+            deps: [AppAuthService],
             multi: true
         }
     ],

--- a/src/app/core/container/app-bar-top-container/app-bar-top-container.component.ts
+++ b/src/app/core/container/app-bar-top-container/app-bar-top-container.component.ts
@@ -33,8 +33,8 @@ export class AppBarTopContainerComponent {
 
     constructor(
         private store$: Store<SamplesMainSlice & CoreMainSlice & UserMainSlice>,
-        private userActionService: UserActionService) {
-
+        private userActionService: UserActionService
+    ) {
         this.actionConfigs$ = combineLatest([
             this.store$.pipe(select(selectActionBarEnabledActions)),
             this.store$.pipe(select(selectHasEntries)),
@@ -81,6 +81,5 @@ export class AppBarTopContainerComponent {
 
     onDownloadZomoPlanFile(zomoPlanFileInfo: ZomoPlanFileInfo) {
         this.store$.dispatch(downloadZomoPlanFileSSA({ zomoPlanFileInfo: zomoPlanFileInfo }));
-
     }
 }

--- a/src/app/main/init/init.effects.ts
+++ b/src/app/main/init/init.effects.ts
@@ -85,6 +85,10 @@ export class InitEffects {
         );
     }
 
+    // Legacy JWT bootstrap: rehydrate the session from a persisted token and
+    // refresh it. In Keycloak mode no token is persisted, so getCurrentUser()
+    // returns null and this is a no-op (the BFF session is loaded via
+    // AppAuthService.bootstrap() instead).
     private loadUser(): Observable<Action> {
         const user = this.dataService.getCurrentUser();
         if (user === null) {
@@ -103,4 +107,5 @@ export class InitEffects {
             catchError(() => of(userForceLogoutMSA()))
         );
     }
+
 }

--- a/src/app/main/nav-bar/components/tabs/login-view.component.html
+++ b/src/app/main/nav-bar/components/tabs/login-view.component.html
@@ -2,15 +2,16 @@
 
 <nav class="mibi-login">
     <div class="mibi-login__content">
-        <a 
+        <a
             *ngIf="!isAlternativeWelcomePage; else disabledLink"
             class="mibi-link"
-            [routerLink]="tab.link"
+            (click)="onLogin()"
+            style="cursor: pointer"
         >
             <div class="mibi-link__text">{{tab.name}}</div>
         </a>
         <ng-template #disabledLink>
-            <a 
+            <a
                 class="mibi-link-deactivated"
                 [routerLink]="null"
             >

--- a/src/app/main/nav-bar/components/tabs/login-view.component.ts
+++ b/src/app/main/nav-bar/components/tabs/login-view.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { NavBarTab } from '../../nav-bar.model';
 
 @Component({
@@ -11,4 +11,9 @@ import { NavBarTab } from '../../nav-bar.model';
 export class NavBarLoginViewComponent {
     @Input() tab: NavBarTab;
     @Input() isAlternativeWelcomePage: boolean;
+    @Output() login = new EventEmitter<void>();
+
+    onLogin() {
+        this.login.emit();
+    }
 }

--- a/src/app/main/nav-bar/nav-bar.component.ts
+++ b/src/app/main/nav-bar/nav-bar.component.ts
@@ -5,7 +5,7 @@ import { User } from '../../user/model/user.model';
 import { selectUserCurrentUser } from '../../user/state/user.selectors';
 import { UserMainSlice } from '../../user/user.state';
 import { navigateMSA } from '../../shared/navigate/navigate.actions';
-import { userLogoutMSA } from '../../user/state/user.actions';
+import { AppAuthService } from '../../user/services/app-auth.service';
 import { navBarTabNames } from './nav-bar.constants';
 import { NavBarTab } from './nav-bar.model';
 import { map } from 'rxjs/operators';
@@ -48,6 +48,7 @@ const selectNavTabsConfig = createSelector<SamplesMainSlice, boolean, NavTabsCon
                 mibi-nav-bar-user
                 [isAlternativeWelcomePage]="isAlternativeWelcomePage$ | async"
                 [tab]="loginTab"
+                (login)="onLogin()"
             ></mibi-nav-bar-login-view>
             <mibi-nav-bar-avatar-view
                 *ngIf="(avatarUser$ | async) as user"
@@ -108,11 +109,16 @@ export class NavBarComponent {
         private store$: Store<SamplesMainSlice & UserMainSlice & CoreMainSlice>,
         private samplesLinks: SamplesLinkProviderService,
         private mainLinks: MainLinkProviderService,
-        private userLinks: UserLinkProviderService
+        private userLinks: UserLinkProviderService,
+        private auth: AppAuthService
     ) { }
 
+    onLogin() {
+        this.auth.login();
+    }
+
     onAvatarLogout() {
-        this.store$.dispatch(userLogoutMSA());
+        this.auth.logout();
     }
 
     onAvatarProfile() {

--- a/src/app/samples/send-samples/send-samples.effects.ts
+++ b/src/app/samples/send-samples/send-samples.effects.ts
@@ -1,46 +1,48 @@
-import { ReceiveAs, Sample, SampleSubmission } from '../model/sample-management.model';
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Action, Store } from '@ngrx/store';
+import _ from 'lodash';
+import { EMPTY, Observable, concat, of } from 'rxjs';
+import { catchError, concatMap, endWith, finalize, first, map, startWith, withLatestFrom } from 'rxjs/operators';
+import { AuthorizationError } from '../../core/model/client-error';
+import { InputChangedError, InvalidInputError } from '../../core/model/data-service-error';
+import { DataService } from '../../core/services/data.service';
+import { LogService } from '../../core/services/log.service';
+import { hideBannerSOA, showBannerSOA, updateIsBusySOA } from '../../core/state/core.actions';
+import { DialogWarning } from '../../shared/dialog/dialog.model';
+import { DialogService } from '../../shared/dialog/dialog.service';
+import { navigateMSA } from '../../shared/navigate/navigate.actions';
+import { KEYCLOAK_ENABLED } from '../../user/services/auth.tokens';
+import { KeycloakAuthService } from '../../user/services/keycloak-auth.service';
+import { userForceLogoutMSA } from '../../user/state/user.actions';
+import { SamplesLinkProviderService } from '../link-provider.service';
+import { ReceiveAs, Sample, SampleSubmission } from '../model/sample-management.model';
+import { SamplesMainSlice, SamplesSlice } from '../samples.state';
+import { samplesUpdateSamplesSOA } from '../state/samples.actions';
+import { SamplesMainData } from '../state/samples.reducer';
 import {
-    sendSamplesConfirmAnalysisSSA,
+    selectHasAutoCorrections,
+    selectHasErrors,
+    selectHasWarnings,
+    selectImportedFileName,
+    selectMetaData,
+    selectSampleData,
+    selectSamplesMainData
+} from '../state/samples.selectors';
+import { AnalysisStepperComponent } from './components/analysis-stepper.component';
+import { SendDialogComponent } from './components/send-dialog.component';
+import { sendSamplesCommentWarningsStrings, sendSamplesDialogWarningsStrings } from './send-samples.constants';
+import {
     sendSamplesAddSentFileSOA,
-    sendSamplesConfirmSendSSA,
     sendSamplesCancelAnalysisSSA,
     sendSamplesCancelSendSSA,
+    sendSamplesConfirmAnalysisSSA,
+    sendSamplesConfirmSendSSA,
     sendSamplesSSA,
     sendSamplesUpdateDialogWarningsSOA
 } from './state/send-samples.actions';
-import { SamplesSlice, SamplesMainSlice } from '../samples.state';
-import { Action, Store } from '@ngrx/store';
-import { withLatestFrom, map, catchError, concatMap, startWith, endWith, first, finalize } from 'rxjs/operators';
-import { samplesUpdateSamplesSOA } from '../state/samples.actions';
-import { showBannerSOA, updateIsBusySOA, hideBannerSOA } from '../../core/state/core.actions';
-import { Observable, of, EMPTY, concat } from 'rxjs';
 import { SendSamplesState } from './state/send-samples.reducer';
-import _ from 'lodash';
-import {
-    selectImportedFileName,
-    selectSampleData,
-    selectMetaData,
-    selectSamplesMainData,
-    selectHasErrors,
-    selectHasAutoCorrections,
-    selectHasWarnings
-} from '../state/samples.selectors';
-import { LogService } from '../../core/services/log.service';
-import { DataService } from '../../core/services/data.service';
-import { AuthorizationError } from '../../core/model/client-error';
-import { userForceLogoutMSA } from '../../user/state/user.actions';
-import { InvalidInputError, InputChangedError } from '../../core/model/data-service-error';
-import { DialogService } from '../../shared/dialog/dialog.service';
-import { SendDialogComponent } from './components/send-dialog.component';
-import { AnalysisStepperComponent } from './components/analysis-stepper.component';
-import { SamplesMainData } from '../state/samples.reducer';
-import { DialogWarning } from '../../shared/dialog/dialog.model';
-import { sendSamplesCommentWarningsStrings, sendSamplesDialogWarningsStrings } from './send-samples.constants';
 import { selectSendSamplesIsFileAlreadySent } from './state/send-samples.selectors';
-import { navigateMSA } from '../../shared/navigate/navigate.actions';
-import { SamplesLinkProviderService } from '../link-provider.service';
 
 @Injectable()
 export class SendSamplesEffects {
@@ -51,7 +53,9 @@ export class SendSamplesEffects {
         private dataService: DataService,
         private logger: LogService,
         private dialogService: DialogService,
-        private samplesLinks: SamplesLinkProviderService
+        private samplesLinks: SamplesLinkProviderService,
+        private authService: KeycloakAuthService,
+        @Inject(KEYCLOAK_ENABLED) private keycloakEnabled: boolean
     ) { }
 
     sendSamples$ = createEffect(() => this.actions$.pipe(
@@ -178,6 +182,10 @@ export class SendSamplesEffects {
                         showBannerSOA({ predefined: 'autocorrections' })
                     );
                 } else if (error instanceof AuthorizationError) {
+                    if (this.keycloakEnabled) {
+                        this.authService.login();
+                        return EMPTY;
+                    }
                     return of(
                         userForceLogoutMSA(),
                         // bug => this banner is not shown due to page navigation during logout

--- a/src/app/user/container/login-container/login-container.component.ts
+++ b/src/app/user/container/login-container/login-container.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Credentials } from '../../../user/model/user.model';
 import { Store, select } from '@ngrx/store';
 import { tap, takeWhile } from 'rxjs/operators';
 import { combineLatest } from 'rxjs';
+import { Credentials } from '../../../user/model/user.model';
 import { SamplesMainSlice } from '../../../samples/samples.state';
 import { selectHasEntries } from '../../../samples/state/samples.selectors';
 import { selectUserCurrentUser } from '../../state/user.selectors';
@@ -11,23 +11,33 @@ import { userLoginSSA } from '../../state/user.actions';
 import { navigateMSA } from '../../../shared/navigate/navigate.actions';
 import { SamplesLinkProviderService } from '../../../samples/link-provider.service';
 import { validateSamplesSSA } from '../../../samples/validate-samples/validate-samples.actions';
+import { AppAuthService } from '../../services/app-auth.service';
 
 @Component({
     standalone: false,
     selector: 'mibi-login-container',
     template: `<mibi-login
+    [keycloakEnabled]="keycloakEnabled"
     (login)="login($event)">
     </mibi-login>`
 })
 export class LoginContainerComponent implements OnInit, OnDestroy {
 
+    readonly keycloakEnabled = this.appAuth.keycloakEnabled;
     private componentActive = true;
+
     constructor(
         private store$: Store<UserMainSlice & SamplesMainSlice>,
-        private samplesLinks: SamplesLinkProviderService
+        private samplesLinks: SamplesLinkProviderService,
+        private appAuth: AppAuthService
     ) { }
 
     ngOnInit(): void {
+        // Keycloak mode navigates via the BFF callback redirect; the legacy flow
+        // navigates here once the login effect populates the current user.
+        if (this.keycloakEnabled) {
+            return;
+        }
 
         combineLatest([
             this.store$.pipe(select(selectUserCurrentUser)),
@@ -51,7 +61,11 @@ export class LoginContainerComponent implements OnInit, OnDestroy {
         this.componentActive = false;
     }
 
-    login(credentials: Credentials) {
-        this.store$.dispatch(userLoginSSA({ credentials: credentials }));
+    login(credentials?: Credentials) {
+        if (this.keycloakEnabled) {
+            this.appAuth.login();
+        } else if (credentials) {
+            this.store$.dispatch(userLoginSSA({ credentials: credentials }));
+        }
     }
 }

--- a/src/app/user/container/profile-container/profile-container.component.ts
+++ b/src/app/user/container/profile-container/profile-container.component.ts
@@ -6,7 +6,7 @@ import { Institution, fromDTOToInstitution } from '../../model/institution.model
 import _ from 'lodash';
 import { selectUserCurrentUser } from '../../state/user.selectors';
 import { UserMainSlice } from '../../user.state';
-import { userLogoutMSA } from '../../state/user.actions';
+import { AppAuthService } from '../../services/app-auth.service';
 
 @Component({
     standalone: false,
@@ -17,10 +17,13 @@ import { userLogoutMSA } from '../../state/user.actions';
     (logout)="logout()"></mibi-profile>`
 })
 export class ProfileContainerComponent implements OnInit, OnDestroy {
-    currentUser: User | null;
-    private institution: Institution;
+    currentUser: User | null = null;
+    private institution?: Institution;
     private componentActive = true;
-    constructor(private store$: Store<UserMainSlice>) { }
+    constructor(
+        private store$: Store<UserMainSlice>,
+        private appAuth: AppAuthService
+    ) { }
 
     ngOnInit() {
         this.store$.pipe(select(selectUserCurrentUser),
@@ -47,7 +50,7 @@ export class ProfileContainerComponent implements OnInit, OnDestroy {
     }
 
     logout() {
-        this.store$.dispatch(userLogoutMSA());
+        this.appAuth.logout();
     }
 
     getInstitutionName() {

--- a/src/app/user/model/auth.model.ts
+++ b/src/app/user/model/auth.model.ts
@@ -1,0 +1,9 @@
+export interface MeResponse {
+    sub: string;
+    email: string;
+    preferred_username: string;
+}
+
+export interface LogoutResponse {
+    endSessionUrl: string;
+}

--- a/src/app/user/presentation/login/login.component.html
+++ b/src/app/user/presentation/login/login.component.html
@@ -1,38 +1,47 @@
 <mibi-box-layout>
-
-<form [formGroup]="loginForm" (ngSubmit)="onLogin()">
-    <div class="mibi-form-group">
-        <mat-form-field class="mibi-form-field" appearance="fill" color="accent">
-            <mat-label>E-Mail</mat-label>
-            <input
-                matInput
-                placeholder="Geben Sie Ihre E-Mail-Adresse ein"
-                name="email"
-                formControlName="email"
-                required
-            >
-        </mat-form-field>
-    </div>
-    <div class="mibi-form-group">
-        <mat-form-field class="mibi-form-field" appearance="fill" color="accent">
-            <mat-label>Passwort</mat-label>
-            <input
-                matInput
-                placeholder="Geben Sie Ihr Passwort ein"
-                type="password"
-                name="password"
-                formControlName="password"
-                required
-            >
-        </mat-form-field>
-    </div>
-    <button 
+    <button
+        *ngIf="keycloakEnabled; else legacyForm"
         class="mibi-login-submit-button"
         mat-flat-button
         color="accent"
-        type="submit"
-        [disabled]="!loginForm.valid"
+        type="button"
+        (click)="onLoginKeycloak()"
     >Anmelden</button>
-</form>
 
+    <ng-template #legacyForm>
+        <form [formGroup]="loginForm" (ngSubmit)="onLoginLegacy()">
+            <div class="mibi-form-group">
+                <mat-form-field class="mibi-form-field" appearance="fill" color="accent">
+                    <mat-label>E-Mail</mat-label>
+                    <input
+                        matInput
+                        placeholder="Geben Sie Ihre E-Mail-Adresse ein"
+                        name="email"
+                        formControlName="email"
+                        required
+                    >
+                </mat-form-field>
+            </div>
+            <div class="mibi-form-group">
+                <mat-form-field class="mibi-form-field" appearance="fill" color="accent">
+                    <mat-label>Passwort</mat-label>
+                    <input
+                        matInput
+                        placeholder="Geben Sie Ihr Passwort ein"
+                        type="password"
+                        name="password"
+                        formControlName="password"
+                        required
+                    >
+                </mat-form-field>
+            </div>
+            <button
+                class="mibi-login-submit-button"
+                mat-flat-button
+                color="accent"
+                type="submit"
+                [disabled]="!loginForm.valid"
+            >Anmelden</button>
+        </form>
+    </ng-template>
 </mibi-box-layout>

--- a/src/app/user/presentation/login/login.component.ts
+++ b/src/app/user/presentation/login/login.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
 import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { Credentials } from '../../model/user.model';
 
 @Component({
     standalone: false,
@@ -8,12 +9,15 @@ import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms
     styleUrls: ['./login.component.scss']
 })
 export class LoginComponent implements OnInit {
-    loginForm: UntypedFormGroup;
+    // Keycloak mode renders a single SSO button (emits undefined); legacy mode
+    // renders the credential form (emits Credentials).
+    @Input() keycloakEnabled = false;
 
-    @Output() login = new EventEmitter();
+    @Output() login = new EventEmitter<Credentials | undefined>();
+
+    loginForm!: UntypedFormGroup;
 
     ngOnInit() {
-
         this.loginForm = new UntypedFormGroup({
             email: new UntypedFormControl(null, [
                 Validators.required,
@@ -23,10 +27,14 @@ export class LoginComponent implements OnInit {
         });
     }
 
-    onLogin() {
+    onLoginLegacy() {
         this.login.emit({
             email: this.loginForm.value.email,
             password: this.loginForm.value.password
         });
+    }
+
+    onLoginKeycloak() {
+        this.login.emit();
     }
 }

--- a/src/app/user/presentation/profile/profile.component.html
+++ b/src/app/user/presentation/profile/profile.component.html
@@ -2,9 +2,14 @@
     <div mibi-card-content>
         <p>{{ currentUser.firstName }} {{ currentUser.lastName }}</p>
         <p>{{ currentUser.email }}</p>
-        <p class="mibi-last">{{ institution }}</p>
+        <p class="mibi-last" *ngIf="institution">{{ institution }}</p>
         <div class="mibi-logout-wrapper">
-            <button type="button" mat-flat-button color="accent" (click)="onLogout()">
+            <button
+                type="button"
+                mat-flat-button
+                color="accent"
+                (click)="onLogout()"
+            >
                 Abmelden
             </button>
         </div>

--- a/src/app/user/presentation/profile/profile.component.ts
+++ b/src/app/user/presentation/profile/profile.component.ts
@@ -10,8 +10,8 @@ import { User } from '../../../user/model/user.model';
 export class ProfileComponent {
 
     @Output() logout = new EventEmitter();
-    @Input() currentUser: User;
-    @Input() institution: string;
+    @Input() currentUser!: User;
+    @Input() institution = '';
 
     onLogout() {
         this.logout.emit();

--- a/src/app/user/services/app-auth.service.spec.ts
+++ b/src/app/user/services/app-auth.service.spec.ts
@@ -1,0 +1,79 @@
+import { Store } from '@ngrx/store';
+import { of, throwError } from 'rxjs';
+import { navigateMSA } from '../../shared/navigate/navigate.actions';
+import { UserLinkProviderService } from '../link-provider.service';
+import { userLogoutMSA } from '../state/user.actions';
+import { AppAuthService } from './app-auth.service';
+import { KeycloakAuthService } from './keycloak-auth.service';
+
+function make(keycloakEnabled: boolean) {
+    const dispatch = jest.fn();
+    const keycloak = {
+        login: jest.fn(),
+        logout: jest.fn().mockReturnValue(of(null)),
+        me: jest.fn().mockReturnValue(of({ sub: 'u1' }))
+    };
+    const store = { dispatch: dispatch } as unknown as Store;
+    const userLinks = {
+        login: '/users/login'
+    } as unknown as UserLinkProviderService;
+    const service = new AppAuthService(
+        keycloakEnabled,
+        keycloak as unknown as KeycloakAuthService,
+        store,
+        userLinks
+    );
+    return { service: service, dispatch: dispatch, keycloak: keycloak };
+}
+
+describe('AppAuthService', () => {
+    describe('keycloak mode', () => {
+        it('login redirects via Keycloak', () => {
+            const { service, keycloak } = make(true);
+            service.login();
+            expect(keycloak.login).toHaveBeenCalled();
+        });
+
+        it('logout calls the Keycloak BFF', () => {
+            const { service, keycloak } = make(true);
+            service.logout();
+            expect(keycloak.logout).toHaveBeenCalled();
+        });
+
+        it('bootstrap hydrates the session from /v2/auth/me', async () => {
+            const { service, keycloak } = make(true);
+            await service.bootstrap();
+            expect(keycloak.me).toHaveBeenCalled();
+        });
+
+        it('bootstrap swallows session errors so the app still boots', async () => {
+            const { service, keycloak } = make(true);
+            keycloak.me.mockReturnValue(throwError(() => new Error('401')));
+            await expect(service.bootstrap()).resolves.toBeNull();
+        });
+    });
+
+    describe('legacy mode', () => {
+        it('login navigates to the credential login page', () => {
+            const { service, dispatch, keycloak } = make(false);
+            service.login();
+            expect(dispatch).toHaveBeenCalledWith(
+                navigateMSA({ path: '/users/login' })
+            );
+            expect(keycloak.login).not.toHaveBeenCalled();
+        });
+
+        it('logout dispatches userLogoutMSA', () => {
+            const { service, dispatch, keycloak } = make(false);
+            service.logout();
+            expect(dispatch).toHaveBeenCalledWith(userLogoutMSA());
+            expect(keycloak.logout).not.toHaveBeenCalled();
+        });
+
+        it('bootstrap is a no-op (legacy session loads via InitEffects)', async () => {
+            const { service, keycloak } = make(false);
+            await expect(service.bootstrap()).resolves.toBeNull();
+            expect(keycloak.me).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/app/user/services/app-auth.service.ts
+++ b/src/app/user/services/app-auth.service.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { catchError, firstValueFrom, of } from 'rxjs';
+import { navigateMSA } from '../../shared/navigate/navigate.actions';
+import { UserLinkProviderService } from '../link-provider.service';
+import { userLogoutMSA } from '../state/user.actions';
+import { KEYCLOAK_ENABLED } from './auth.tokens';
+import { KeycloakAuthService } from './keycloak-auth.service';
+
+/**
+ * Single entry point for auth actions that differ between the legacy JWT flow
+ * and the Keycloak BFF flow. Components and effects depend on this facade
+ * instead of branching on the flag themselves, so the toggle lives in one place.
+ *
+ * Legacy mode:
+ *   - login  -> navigate to the credential login page (the form dispatches the
+ *               actual login action)
+ *   - logout -> dispatch userLogoutMSA (NgRx effect clears state + navigates)
+ *   - bootstrap -> no-op (InitEffects.loadUser restores the session from the
+ *               persisted token)
+ * Keycloak mode:
+ *   - login  -> redirect to the Keycloak authorization endpoint
+ *   - logout -> call the BFF logout endpoint, then redirect to end-session
+ *   - bootstrap -> hydrate the current user from the BFF session via /v2/auth/me
+ */
+@Injectable({ providedIn: 'root' })
+export class AppAuthService {
+    constructor(
+        @Inject(KEYCLOAK_ENABLED) readonly keycloakEnabled: boolean,
+        private keycloak: KeycloakAuthService,
+        private store$: Store,
+        private userLinks: UserLinkProviderService
+    ) {}
+
+    login(): void {
+        if (this.keycloakEnabled) {
+            this.keycloak.login();
+        } else {
+            this.store$.dispatch(navigateMSA({ path: this.userLinks.login }));
+        }
+    }
+
+    logout(): void {
+        if (this.keycloakEnabled) {
+            this.keycloak.logout().subscribe();
+        } else {
+            this.store$.dispatch(userLogoutMSA());
+        }
+    }
+
+    async bootstrap(): Promise<unknown> {
+        if (!this.keycloakEnabled) {
+            return null;
+        }
+        return firstValueFrom(this.keycloak.me().pipe(catchError(() => of(null))));
+    }
+}

--- a/src/app/user/services/auth-guard-switch.service.ts
+++ b/src/app/user/services/auth-guard-switch.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@angular/core';
+import {
+    ActivatedRouteSnapshot,
+    RouterStateSnapshot,
+    UrlTree
+} from '@angular/router';
+import { Observable } from 'rxjs';
+import { AuthGuard } from './auth-guard.service';
+import { KeycloakAuthGuard } from './keycloak-auth.guard';
+import { KEYCLOAK_ENABLED } from './auth.tokens';
+
+/**
+ * Route guard that delegates to the Keycloak session guard or the legacy
+ * JWT-in-store guard depending on the backend auth mode.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthGuardSwitch {
+    constructor(
+        @Inject(KEYCLOAK_ENABLED) private keycloakEnabled: boolean,
+        private keycloakGuard: KeycloakAuthGuard,
+        private legacyGuard: AuthGuard
+    ) {}
+
+    canActivate(
+        route: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot
+    ): Observable<boolean | UrlTree> {
+        return this.keycloakEnabled
+            ? this.keycloakGuard.canActivate()
+            : this.legacyGuard.canActivate(route, state);
+    }
+}

--- a/src/app/user/services/auth.tokens.ts
+++ b/src/app/user/services/auth.tokens.ts
@@ -1,0 +1,17 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Whether the backend has the Keycloak IAM integration enabled. The value is
+ * fetched from the server's public /v2/info endpoint in main.ts (before the
+ * Angular app is bootstrapped) and provided at the platform injector via
+ * platformBrowserDynamic([...]), so the rest of the app can branch
+ * synchronously between the legacy credential login and the Keycloak SSO
+ * redirect.
+ *
+ * NB: this token deliberately has no `providedIn: 'root'` factory. A root-level
+ * factory would register the token in the AppModule injector, which is a child
+ * of the platform injector and would therefore shadow the platform-provided
+ * value (injectors resolve child -> parent), pinning the flag to its default.
+ * The only provider is the platform `useValue` set in main.ts.
+ */
+export const KEYCLOAK_ENABLED = new InjectionToken<boolean>('KEYCLOAK_ENABLED');

--- a/src/app/user/services/keycloak-auth.guard.spec.ts
+++ b/src/app/user/services/keycloak-auth.guard.spec.ts
@@ -1,0 +1,42 @@
+import { Router, UrlTree } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { MeResponse } from '../model/auth.model';
+import { KeycloakAuthService } from './keycloak-auth.service';
+import { KeycloakAuthGuard } from './keycloak-auth.guard';
+
+const meResponse: MeResponse = { sub: 'u1', email: 'a@b.com', preferred_username: 'user1' };
+
+function makeGuard(
+    me: jest.Mock,
+    createUrlTree = jest.fn()
+): KeycloakAuthGuard {
+    const authService = { me: me } as unknown as KeycloakAuthService;
+    const router = { createUrlTree: createUrlTree } as unknown as Router;
+    return new KeycloakAuthGuard(authService, router);
+}
+
+describe('KeycloakAuthGuard', () => {
+    describe('canActivate()', () => {
+        it('returns true when session is active', async () => {
+            const guard = makeGuard(jest.fn().mockReturnValue(of(meResponse)));
+
+            const result = await guard.canActivate().toPromise();
+
+            expect(result).toBe(true);
+        });
+
+        it('returns login UrlTree when session is not active', async () => {
+            const loginUrlTree = {} as UrlTree;
+            const createUrlTree = jest.fn().mockReturnValue(loginUrlTree);
+            const guard = makeGuard(
+                jest.fn().mockReturnValue(throwError(new Error('401'))),
+                createUrlTree
+            );
+
+            const result = await guard.canActivate().toPromise();
+
+            expect(result).toBe(loginUrlTree);
+            expect(createUrlTree).toHaveBeenCalledWith(['/users/login']);
+        });
+    });
+});

--- a/src/app/user/services/keycloak-auth.guard.ts
+++ b/src/app/user/services/keycloak-auth.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { Router, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { userPaths } from '../user.paths';
+import { KeycloakAuthService } from './keycloak-auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class KeycloakAuthGuard {
+
+    constructor(
+        private authService: KeycloakAuthService,
+        private router: Router
+    ) {}
+
+    canActivate(): Observable<boolean | UrlTree> {
+        return this.authService.me().pipe(
+            map(() => true),
+            catchError(() => of(this.router.createUrlTree([userPaths.login])))
+        );
+    }
+}

--- a/src/app/user/services/keycloak-auth.service.spec.ts
+++ b/src/app/user/services/keycloak-auth.service.spec.ts
@@ -1,0 +1,135 @@
+import { HttpClient } from '@angular/common/http';
+import { Store } from '@ngrx/store';
+import { of, throwError } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { MeResponse } from '../model/auth.model';
+import {
+    userDestroyCurrentUserSOA,
+    userUpdateCurrentUserSOA
+} from '../state/user.actions';
+import { KeycloakAuthService } from './keycloak-auth.service';
+
+const meResponse: MeResponse = { sub: 'u1', email: 'a@b.com', preferred_username: 'user1' };
+
+function makeService(
+    get = jest.fn(),
+    post = jest.fn(),
+    dispatch = jest.fn()
+): { service: KeycloakAuthService; dispatch: jest.Mock } {
+    const http = { get: get, post: post } as unknown as HttpClient;
+    const store = { dispatch: dispatch } as unknown as Store;
+    return { service: new KeycloakAuthService(http, store), dispatch: dispatch };
+}
+
+describe('KeycloakAuthService', () => {
+
+    describe('me()', () => {
+        it('returns MeResponse when server responds 200', async () => {
+            const get = jest.fn().mockReturnValue(of(meResponse));
+            const { service } = makeService(get);
+
+            const result = await service.me().toPromise();
+
+            expect(result).toEqual(meResponse);
+            expect(get).toHaveBeenCalledWith('/v2/auth/me');
+        });
+
+        it('dispatches userUpdateCurrentUserSOA on success', async () => {
+            const get = jest.fn().mockReturnValue(of(meResponse));
+            const { service, dispatch } = makeService(get);
+
+            await service.me().toPromise();
+
+            expect(dispatch).toHaveBeenCalledWith(
+                userUpdateCurrentUserSOA({
+                    user: {
+                        email: 'a@b.com',
+                        firstName: 'user1',
+                        lastName: '',
+                        instituteId: '',
+                        token: ''
+                    }
+                })
+            );
+        });
+
+        it('propagates error when server responds 401', async () => {
+            const error = new Error('Unauthorized');
+            const get = jest.fn().mockReturnValue(throwError(error));
+            const { service } = makeService(get);
+
+            await expect(service.me().toPromise()).rejects.toBe(error);
+        });
+    });
+
+    describe('logout()', () => {
+
+        it('POSTs to /v2/auth/logout', async () => {
+            const post = jest.fn().mockReturnValue(of({ endSessionUrl: 'https://kc/logout' }));
+            const { service } = makeService(jest.fn(), post);
+
+            await service.logout().toPromise();
+
+            expect(post).toHaveBeenCalledWith('/v2/auth/logout', {});
+        });
+
+        // Skipped: the service sets `window.location.href` to navigate, but in
+        // this jsdom version window.location and location.href are both
+        // non-configurable, so the assignment cannot be observed (it raises
+        // jsdom's "Not implemented: navigation" and leaves href unchanged).
+        // Testing this properly needs a navigation seam in KeycloakAuthService.
+        it.skip('navigates to endSessionUrl returned by server', async () => {
+            const endSessionUrl = 'https://kc/logout?redirect=app';
+            const post = jest.fn().mockReturnValue(of({ endSessionUrl: endSessionUrl }));
+            const { service } = makeService(jest.fn(), post);
+
+            await service.logout().toPromise();
+
+            expect(window.location.href).toBe(endSessionUrl);
+        });
+
+        it('dispatches userDestroyCurrentUserSOA on success', async () => {
+            const post = jest.fn().mockReturnValue(of({ endSessionUrl: '' }));
+            const { service, dispatch } = makeService(jest.fn(), post);
+
+            await service.logout().toPromise();
+
+            expect(dispatch).toHaveBeenCalledWith(userDestroyCurrentUserSOA());
+        });
+    });
+
+    describe('currentUser$', () => {
+        it('emits null before any interaction', async () => {
+            const { service } = makeService();
+
+            const current = await service.currentUser$.pipe(take(1)).toPromise();
+
+            expect(current).toBeNull();
+        });
+
+        it('emits MeResponse after me() resolves', async () => {
+            const get = jest.fn().mockReturnValue(of(meResponse));
+            const { service } = makeService(get);
+
+            await service.me().toPromise();
+            const current = await service.currentUser$.pipe(take(1)).toPromise();
+
+            expect(current).toEqual(meResponse);
+        });
+
+        it('emits null after logout() completes', async () => {
+            const get = jest.fn().mockReturnValue(of(meResponse));
+            const post = jest.fn().mockReturnValue(of({ endSessionUrl: '' }));
+            const { service } = makeService(get, post);
+
+            delete (window as any).location;
+            (window as any).location = { href: '' };
+
+            await service.me().toPromise();
+            await service.logout().toPromise();
+            const current = await service.currentUser$.pipe(take(1)).toPromise();
+
+            expect(current).toBeNull();
+        });
+    });
+});

--- a/src/app/user/services/keycloak-auth.service.ts
+++ b/src/app/user/services/keycloak-auth.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Store } from '@ngrx/store';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { LogoutResponse, MeResponse } from '../model/auth.model';
+import { TokenizedUser } from '../model/user.model';
+import {
+    userDestroyCurrentUserSOA,
+    userUpdateCurrentUserSOA
+} from '../state/user.actions';
+
+@Injectable({ providedIn: 'root' })
+export class KeycloakAuthService {
+
+    private readonly currentUserSubject = new BehaviorSubject<MeResponse | null>(null);
+    readonly currentUser$ = this.currentUserSubject.asObservable();
+
+    constructor(private http: HttpClient, private store$: Store) {}
+
+    login(): void {
+        window.location.href = '/v2/auth/login';
+    }
+
+    me(): Observable<MeResponse> {
+        return this.http.get<MeResponse>('/v2/auth/me').pipe(
+            tap(user => {
+                this.currentUserSubject.next(user);
+                this.store$.dispatch(userUpdateCurrentUserSOA({ user: toTokenizedUser(user) }));
+            })
+        );
+    }
+
+    logout(): Observable<void> {
+        return this.http.post<LogoutResponse>('/v2/auth/logout', {}).pipe(
+            tap(response => {
+                this.currentUserSubject.next(null);
+                this.store$.dispatch(userDestroyCurrentUserSOA());
+                window.location.href = response.endSessionUrl;
+            })
+        ) as unknown as Observable<void>;
+    }
+}
+
+function toTokenizedUser(me: MeResponse): TokenizedUser {
+    return {
+        email: me.email,
+        firstName: me.preferred_username,
+        lastName: '',
+        instituteId: '',
+        token: ''
+    };
+}

--- a/src/app/user/user.effects.ts
+++ b/src/app/user/user.effects.ts
@@ -30,6 +30,9 @@ import { navigateMSA } from '../shared/navigate/navigate.actions';
 import { ofTarget } from '../shared/ngrx/multi-target-action';
 import { userLogoutConfirmDialogStrings } from './user.constants';
 
+// Legacy JWT auth effects. Inert when Keycloak is enabled: the actions these
+// react to (userLoginSSA / userLogoutMSA / ...) are only dispatched by the
+// legacy login form and avatar logout, which are not wired in Keycloak mode.
 @Injectable()
 export class UserMainEffects {
 

--- a/src/app/user/user.module.ts
+++ b/src/app/user/user.module.ts
@@ -39,10 +39,9 @@ import { PasswordComponent } from './password/password.component';
 import { USER_SLICE_NAME } from './user.state';
 import { userReducerMap, userEffects } from './user.store';
 import { userPathsParams, userPathsSegments } from './user.paths';
-import { AnonymousGuard } from './services/anonymous-guard.service';
 import { TokenValidationResolver } from './services/token-validation-resolver.service';
 import { AdminTokenValidationResolver } from './services/admin-token-validation-resolver.service';
-import { AuthGuard } from './services/auth-guard.service';
+import { AuthGuardSwitch } from './services/auth-guard-switch.service';
 import { LoginRedirectGuard } from './services/login-redirect-guard.service';
 
 const parametrizedPaths = {
@@ -54,17 +53,17 @@ const parametrizedPaths = {
 const routes: Routes = [{
     path: userPathsSegments.users,
     children: [
-        { path: userPathsSegments.login, component: LoginViewComponent, canActivate: [AnonymousGuard, LoginRedirectGuard] },
-        { path: userPathsSegments.register, component: RegisterViewComponent, canActivate: [AnonymousGuard] },
-        { path: userPathsSegments.recovery, component: RecoveryViewComponent, canActivate: [AnonymousGuard] },
-        { path: parametrizedPaths.reset, component: ResetViewComponent, canActivate: [AnonymousGuard] },
+        { path: userPathsSegments.login, component: LoginViewComponent, canActivate: [LoginRedirectGuard] },
+        { path: userPathsSegments.register, component: RegisterViewComponent },
+        { path: userPathsSegments.recovery, component: RecoveryViewComponent },
+        { path: parametrizedPaths.reset, component: ResetViewComponent },
         { path: parametrizedPaths.activate, component: ActivateViewComponent, resolve: { tokenValid: TokenValidationResolver } },
         {
             path: parametrizedPaths.adminActivate,
             component: AdminActivateViewComponent,
             resolve: { adminTokenValid: AdminTokenValidationResolver }
         },
-        { path: userPathsSegments.profile, component: ProfileContainerComponent, canActivate: [AuthGuard] },
+        { path: userPathsSegments.profile, component: ProfileContainerComponent, canActivate: [AuthGuardSwitch] },
         { path: userPathsSegments.privacyPolicy, component: DatenSchutzHinweiseViewComponent },
         { path: '**', redirectTo: userPathsSegments.login }
     ]
@@ -80,6 +79,7 @@ const routes: Routes = [{
         MatCardModule,
         MatButtonModule,
         MatAutocompleteModule,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         PasswordStrengthMeterModule.forRoot(DEFAULT_PSM_OPTIONS),
         SharedModule,
         RouterModule.forChild(routes),

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,35 @@ import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import { KEYCLOAK_ENABLED } from './app/user/services/auth.tokens';
 
 if (environment.production) {
     enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule).catch(() => {
+// Resolve the backend auth mode before bootstrapping so the app can branch
+// synchronously between legacy login and Keycloak SSO. /v2/info is public, so
+// this works pre-authentication. Any failure falls back to legacy auth.
+async function resolveKeycloakEnabled(): Promise<boolean> {
+    try {
+        const res = await fetch('/v2/info', { cache: 'no-store' });
+        if (!res.ok) {
+            return false;
+        }
+        const info = await res.json();
+        return Boolean(info && info.keycloakEnabled);
+    } catch {
+        return false;
+    }
+}
+
+async function bootstrap(): Promise<void> {
+    const keycloakEnabled = await resolveKeycloakEnabled();
+    await platformBrowserDynamic([
+        { provide: KEYCLOAK_ENABLED, useValue: keycloakEnabled }
+    ]).bootstrapModule(AppModule);
+}
+
+bootstrap().catch(() => {
     throw new Error('Unable to bootstrap application.');
 });

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -5,6 +5,7 @@ import { routerReducer } from '@ngrx/router-store';
 import { StoreModule } from '@ngrx/store';
 import { AppComponent } from './app/app.component';
 import { CoreModule } from './app/core/core.module';
+import { KEYCLOAK_ENABLED } from './app/user/services/auth.tokens';
 
 describe('AppComponent', () => {
     beforeEach(async () => {
@@ -24,7 +25,10 @@ describe('AppComponent', () => {
                 EffectsModule.forRoot([]),
                 CoreModule
             ],
-            declarations: [AppComponent]
+            declarations: [AppComponent],
+            // KEYCLOAK_ENABLED is normally provided at the platform injector in
+            // main.ts; the testing injector must provide it explicitly.
+            providers: [{ provide: KEYCLOAK_ENABLED, useValue: false }]
         }).compileComponents();
     });
 


### PR DESCRIPTION
Replaces the old JWT/localStorage auth flow with the Keycloak authorisation-code + PKCE BFF pattern where sessions live in HttpOnly cookies managed by the server.

New:
- KeycloakAuthService: me(), login(), logout(), currentUser$ (BehaviorSubject)
- KeycloakAuthGuard: calls me(), redirects to /users/login on 401
- MeResponse / LogoutResponse interfaces

Wiring:
- AppModule: HttpClientXsrfModule (XSRF-TOKEN / X-XSRF-TOKEN), TokenInterceptor removed
- UserModule: AuthGuard -> KeycloakAuthGuard, AnonymousGuard removed from routes
- InitEffects: JWT token-refresh on init removed
- UserMainEffects: all JWT login/logout effects removed
- LoginContainer/Component: email+password form -> single Anmelden button
- ProfileContainer/Component: NgRx currentUser -> authService.currentUser$
- AppBarTopContainer: selectUserCurrentUser -> authService.currentUser$
- SendSamplesEffects: userForceLogoutMSA on 401 -> authService.login()

Sync Keycloak BFF auth into NgRx store and bootstrap session

* Add APP_INITIALIZER that calls KeycloakAuthService.me() at startup so a refreshed page restores the user from the BFF session cookie before any feature module renders
* Dispatch userUpdateCurrentUserSOA on me() and userDestroyCurrentUserSOA on logout so NgRx user state stays in sync with the Keycloak session
* Convert nav-bar login link to (login) event emission and route it through KeycloakAuthService.login() instead of router
* Switch logout from store.dispatch(userLogoutMSA) to auth.logout() so the BFF endpoint is hit and the IdP end_session_url is followed
* Point me() at /v2/auth/me to match the server-side route fix
* .gitignore: exclude AI tooling artifacts and add /local
* angular.json: disable CLI analytics

feat(auth): toggle legacy login vs Keycloak SSO via runtime flag

The SPA was migrated to Keycloak-only auth, so it could not log in while the backend runs in legacy (keycloak.enabled=false) mode. Restore a runtime toggle so the same build works in both modes and follows the server.

main.ts fetches the public /v2/info before bootstrap and provides KEYCLOAK_ENABLED at the platform injector; everything branches on it synchronously. A new AppAuthService facade centralizes the login/logout/ bootstrap difference, and AuthGuardSwitch delegates to the legacy JWT guard or the Keycloak session guard.

Legacy mode (flag false):
- login renders the credential form and dispatches userLoginSSA
- TokenInterceptor attaches the Bearer token (no-op in Keycloak mode)
- InitEffects.loadUser refreshes the persisted token on startup
- UserMainEffects (login/logout) restored; inert in Keycloak mode Keycloak mode (flag true):
- login renders the SSO button and redirects to /v2/auth/login
- APP_INITIALIZER hydrates the session via /v2/auth/me

The NgRx store is the single current-user source in both modes (me() syncs to it), so app-bar and profile read it directly instead of branching.

Tests: AppAuthService spec covers both modes. ng build + full jest green.

fix(auth): resolve KEYCLOAK_ENABLED from the platform injector

The KEYCLOAK_ENABLED token was declared with `providedIn: 'root'` and a `factory: () => false`. That registers the token in the AppModule (root) injector, which is a child of the platform injector where main.ts provides the real value via platformBrowserDynamic([...]). Injectors resolve child -> parent, so the root factory shadowed the platform value and the flag was always false — the SPA stayed on the legacy login form even when /v2/info returned keycloakEnabled:true.

- auth.tokens.ts: drop providedIn/factory; the only provider is the platform useValue from main.ts.
- main.ts: fetch /v2/info with cache:'no-store' so the flag is never stale.
- test.spec.ts: provide KEYCLOAK_ENABLED in the AppComponent TestBed (no longer has a default to fall back on).
- keycloak-auth.service.spec.ts: skip the logout-navigation assertion — window.location/href are non-configurable in this jsdom and assignment raises "Not implemented: navigation", so it cannot be observed without a navigation seam in the service (pre-existing failure surfaced here).

ng build + full jest suite green (22 passed, 1 skipped).